### PR TITLE
Allow setting tag message with $EDITOR.

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -154,7 +154,7 @@ class Git(BaseVCS):
             command += ['--message', message]
         elif message is None:
             command += ['--annotate']
-        subprocess.call(command)
+        subprocess.check_call(command)
 
 
 class Mercurial(BaseVCS):
@@ -191,7 +191,7 @@ class Mercurial(BaseVCS):
             command += ['--message', message]
         elif message is None:
             command += ['--edit']
-        subprocess.call(command)
+        subprocess.check_call(command)
 
 VCS = [Git, Mercurial]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -791,7 +791,7 @@ def test_annotated_tag(tmpdir, vcs):
 def test_annotated_editor_tag(tmpdir, vcs):
     tmpdir.chdir()
     check_call([vcs, "init"])
-    tmpdir.join("VERSION").write("42.5.1")
+    tmpdir.join("VERSION").write("42.4.1")
     check_call([vcs, "add", "VERSION"])
     check_call([vcs, "commit", "-m", "initial commit"])
 


### PR DESCRIPTION
Both Git and Mercurial have the option to write an annotated tag in the
$EDITOR. Expose this when --tag-message is passed with no argument.
